### PR TITLE
Fix `col` in Neovim 0.6

### DIFF
--- a/lua/nvim-ale-diagnostic.lua
+++ b/lua/nvim-ale-diagnostic.lua
@@ -28,7 +28,7 @@ if vim.version().api_level == 8 then
         text = item.message,
         lnum = item.lnum+1,
         end_lnum = item.end_lnum,
-        col = item.col,
+        col = item.col+1,
         end_col = item.end_col,
         type = ale_diagnostic_severity_map[item.severity]
       })


### PR DESCRIPTION
I'm not sure why this code was different from the 0.5 version, but
without this change the highlight appears in the wrong place for me.