### PR TITLE
Avoid making redundant calls to `ShowResults`

### DIFF
--- a/lua/nvim-ale-diagnostic.lua
+++ b/lua/nvim-ale-diagnostic.lua
@@ -10,6 +10,7 @@ vim.lsp.diagnostic.clear = function(bufnr, client_id, diagnostic_ns, sign_ns)
   vim.lsp.diagnostic.original_clear(bufnr, client_id, diagnostic_ns, sign_ns)
   -- Clear ALE
   vim.api.nvim_call_function('ale#other_source#ShowResults', {bufnr, "nvim-lsp", {}})
+  vim.b[bufnr].prev_nvim_lsp_diagnostics = nil
 end
 
 if vim.version().api_level == 8 then
@@ -34,7 +35,14 @@ if vim.version().api_level == 8 then
       })
     end
 
-    vim.api.nvim_call_function('ale#other_source#ShowResults', {bufnr, "nvim-lsp", items})
+    -- Only call `ShowResults` if the diagnostics have actually changed
+    if not vim.deep_equal(vim.b[bufnr].prev_nvim_lsp_diagnostics, items) then
+      vim.api.nvim_call_function(
+        'ale#other_source#ShowResults',
+        {bufnr, "nvim-lsp", items}
+      )
+      vim.b[bufnr].prev_nvim_lsp_diagnostics = items
+    end
   end
 
   function vim.diagnostic.show(namespace, bufnr, ...)
@@ -62,4 +70,3 @@ else
     vim.api.nvim_call_function('ale#other_source#ShowResults', {bufnr, "nvim-lsp", items})
   end
 end
-


### PR DESCRIPTION
After setting up LSP and Ale, I started seeing a bunch of weird behavior
(flickering cursor, the statusline flipping back and forth between
messages, etc.) that seems to be caused by LSP making multiple calls to
`vim.diagnostic.show` even when the diagnostics aren't actually
changing. I'm not sure if this is a new issue with the Neovim 0.6 API or
already existed with the old one.

This commit updates `set_signs` to only call `ShowResults` once for a
given set of diagnostics, which we achieve by hanging onto a copy in a
buffer-scoped variable and then comparing it against the new data on
each call. This seems to completely resolve the issues I was having.